### PR TITLE
Remove setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,5 +159,5 @@ paths = ["cemm"]
 verbose = true
 
 [build-system]
-requires = ["setuptools","poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I saw that `setuptools` was added in https://github.com/klaasnicolaas/python-cemm/commit/7a0e140e9879bf10771b7f602b0876ad94e70aee, but I don't think it's needed? Optimistically opening up a PR to remove it again. (I plan to use this patch when building this package in [nixpkgs](https://github.com/NixOS/nixpkgs))